### PR TITLE
chore: add license to package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-present Tanner Linsley
+Copyright (c) 2022-present Jørn Andre
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/batshit/package.json
+++ b/packages/batshit/package.json
@@ -6,6 +6,7 @@
     "name": "Jørn Andre",
     "url": "https://github.com/yornaath/batshit"
   },
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/devtools-react/package.json
+++ b/packages/devtools-react/package.json
@@ -6,6 +6,7 @@
     "name": "Jørn Andre",
     "url": "https://github.com/yornaath"
   },
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -6,6 +6,7 @@
     "name": "Jørn Andre",
     "url": "https://github.com/yornaath/batshit"
   },
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
I assume you want to retain the copyright of the code, so I updated the name to be yours (as well as the year since this project was created at the end of 2022)

I also added the license to the package's package.json so that npm (as well as policy auditing tooling) can easily pick it up.