### PR TITLE
Add support for ReadonlyArray<T> for keyResolver

### DIFF
--- a/packages/batshit/src/index.ts
+++ b/packages/batshit/src/index.ts
@@ -190,8 +190,8 @@ export const create = <T, Q, R = T>(
  * @returns (item:T extends Array<A>, query: Q) => A
  */
 export const keyResolver =
-  <T extends Array<any>, Q, R = T extends Array<infer A> ? A : never>(
-    key: T extends Array<infer A> ? keyof A : never
+  <T extends ReadonlyArray<any>, Q, R = T extends ReadonlyArray<infer A> ? A : never>(
+    key: T extends ReadonlyArray<infer A> ? keyof A : never
   ) =>
   (items: T, query: Q): R =>
     items.find((item) => item[key] == query) ?? null;


### PR DESCRIPTION
With the current signature of `keyResolver`, `fetcher` is required to return mutable arrays. However, `keyResolver` doesn't mutate the array, so it should be able to leverage `ReadonlyArray`s.

[Typescript Playground](https://www.typescriptlang.org/play/?ts=5.5.0-beta#code/JYWwDg9gTgLgBAbwMZQKYEMaoDRwNaoCeASqgM4QA2AbqlAL5wBmUEIcA5AAKHQB26TAAsA9ACNMZIcBgcA3ACgFTAK58kMYBD5wA5qhgBVMnTIA5dCHIAKAJQAuOKXQATbZUIBBKFHSEAPAjALo58KiBidLgCVo5kMFDAfLr0AHyICnBwaDAqUDoA2kEhcACM0ZaojhwAEipEHPS4xY4ATBWxnAAiqADuDU2IwY4AzB1VnAAyECrAqI0Auor0Skja8XASMEhCdHAAvHAoGFjWCJnMBjt0juhkhOpw1sFkjs5ufB7evgFhEXSpWwHdL6IwmKDmSpkOzYC5oCg0G74IikBG0KDWDjBDi2BT0XEKVAAD0gsCO63gfD6AGkUeQqOiDhd-AAVODErB8FxkJwYD5fHx+fzoPiEVK4ACKuGIBzgbI5qC5PPe7i8goCSSYe086QA-HBPHBQqh0alrBcsgRCI55UTOdzea5Vd8hZrtXrkbwmAajXAqeiLkD9qkLs8sCBXnLcABHepQa1wCUOJzAi1wGSoCMAOiYSRc1jDmaD6QzIAKVoWB0OsbohCBuv1YUolEUCjWfA2aCdn0IACFMNcoLLjphUGcLlrtrsoLd7o9nty3nzner-H9IlBAcC9AZjKYLFZobZYVl4QykVTerSSPTERisS4cXjbEA)

