### PR TITLE
fix: key resolver return type

### DIFF
--- a/packages/batshit/src/index.ts
+++ b/packages/batshit/src/index.ts
@@ -187,13 +187,13 @@ export const create = <T, Q, R = T>(
  * Create a euquality check to check if the query matches a given key on the item data.
  *
  * @param key keyof T
- * @returns (item:T extends Array<A>, query: Q) => A
+ * @returns (item:T extends Array<A>, query: Q) => A | null
  */
 export const keyResolver =
   <T extends ReadonlyArray<any>, Q, R = T extends ReadonlyArray<infer A> ? A : never>(
     key: T extends ReadonlyArray<infer A> ? keyof A : never
   ) =>
-    (items: T, query: Q): R =>
+    (items: T, query: Q): R | null =>
       items.find((item) => item[key] === query) ?? null;
 
 /**

--- a/packages/batshit/tests/index.test.ts
+++ b/packages/batshit/tests/index.test.ts
@@ -166,6 +166,21 @@ const tests = () => {
     ]);
   });
 
+  test("key resolver", async () => {
+    const batcher = create({
+      fetcher: async (ids: number[]) => {
+        return mock.usersByIds(ids.filter((id) => id !== 2));
+      },
+      resolver: keyResolver("id"),
+    });
+
+    const two = await batcher.fetch(2);
+    expect(two).toBeNull();
+
+    const three = await batcher.fetch(3);
+    expect(three).toEqual({ id: 3, name: "Sally" });
+  });
+
   test("custom resolver", async () => {
     let fetchCounter = 0;
     const batcher = create({


### PR DESCRIPTION
Fixes the return type of `keyResolver` as this function can return a null value that is currently being explicitly defined as `R`.